### PR TITLE
Changes to allow for entering custom admin url.

### DIFF
--- a/generator/descriptionsBuilder.ts
+++ b/generator/descriptionsBuilder.ts
@@ -83,7 +83,7 @@ const mapParam = (param: IParam, display?: [res: string, op: string]): INodeProp
 };
 
 const getParams = (op: IOperation, resourceName: string): INodeProperties[] => {
-	return (op.params as IParam[]).map(p => mapParam(p, [resourceName, op.name]));
+	return (op.params as IParam[]).map(p => mapParam(p, [resourceName, op.name || '']));
 };
 
 export type DescriptionsDict = {[key: string]: INodeProperties | INodeProperties[]};

--- a/nodes/HostBill/OperatonExecutor.ts
+++ b/nodes/HostBill/OperatonExecutor.ts
@@ -20,7 +20,7 @@ export type Mappers = {[mapper: string]: (value: any) => string | undefined};
 
 type Dict<T> = {[key: string]: T};
 
-export const normalizeHost = (hostName: string) => hostName.replace(/\/$/, '');
+export const normalizeHost = (hostName: string) => hostName.replace(/\/$/, '').replace('/api.php', '');
 
 const pick = (obj: IDataObject, props: string[]) => props.reduce((acc, i) => {
 	acc[i] = obj[i];
@@ -138,7 +138,7 @@ export class OperationExecutor {
 				'Content-Type': 'application/json',
 			},
 			method: 'GET',
-			uri: normalizeHost(this.credentials.server) + '/admin/api.php',
+			uri: normalizeHost(this.credentials.server) + (this.credentials.server.match(/\/.+\/.+$/gm) ? '' : '/admin') + '/api.php',
 			json: true,
 			qs: Object.assign(credParams, params),
 		};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@digital-boss/n8n-nodes-hostbill",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-boss/n8n-nodes-hostbill",
-      "version": "0.1.0",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "version": "0.1.3",
+      "license": "MIT",
       "dependencies": {
         "n8n-core": "~0.119.0"
       },


### PR DESCRIPTION
generator/descriptionsBuilder.ts
- Fixed a weak type error

nodes/HostBill/OperatonExecutor.ts
- Removed the hardcoded admin url and replaced it with the one entered in the credentials
- Modified normalize credential url function to strip trailing /api.php